### PR TITLE
Update plugin-dev pages

### DIFF
--- a/_plugin-dev/basics.md
+++ b/_plugin-dev/basics.md
@@ -3,18 +3,16 @@ toc:
     basics:
         _title: Basics
         versioning: Versioning
-        build_&_release: Build & Release
+        build--release: Build & Release
 nav: 1
 ---
 
 # Basics
 Creating your own content for Pico is *easy*.
 
-Inside the root Pico folder, all *themes* reside in the `themes` directory,
-and all *plugins* in the `plugins` directory. (As a developer, you may have
-changed these paths and/or directory names when you initialized Pico.)
+Inside the root Pico folder, all *themes* reside in the `themes` directory, and all *plugins* in the `plugins` directory. (As a developer, you may have changed these paths and/or directory names when you initialized Pico.)
 
-Besides this documentation please also refer to our [phpDoc](phpDocumentor/).
+Note that if you are submitting pull requests they should be small (i.e. one feature per request), stick to existing coding conventions and documentation should be updated if required.
 
 # Versioning
 Pico uses Semantic Versioning. Given a version number MAJOR.MINOR.PATCH, increment the:
@@ -26,11 +24,21 @@ Pico uses Semantic Versioning. Given a version number MAJOR.MINOR.PATCH, increme
 For more information see the [http://semver.org](http://semver.org) website.
 
 # Build & Release
-Defined below is a specification to which the Build and Release process of Pico should follow.
-Each commit to `master` should be releasable, otherwise make use of the `development` branch.
+Defined below is a specification to which the Build and Release process of Pico should follow. We use `travis-ci` to automate the process, and each commit to `master` should be releasable.
 
 ### Commit phase
+- Commit changes
 - Create & Push Git tag
+- Trigger automatic build process...
+
+Example commit message:
+
+    Pico 1.0.1
+    * [New] ...
+    * [Changed] ...
+
+*Please submit pull-requests with a properly
+formatted commit message/SemVer increase to avoid the need for manual amendments.*
 
 ### Analysis phase
 - Run through `scrutinizer-ci`?
@@ -38,7 +46,7 @@ Each commit to `master` should be releasable, otherwise make use of the `develop
 ### Packaging phase
 - Run composer locally
 - Create a ZIP archive (so vendor/ is included)
-- Build documentation, output goes to a new folder in the gh-pages branch
+- Build documentation, output goes to a new folder in the `gh-pages` branch
 
 ### Release phase
 - Create new Git release at tag
@@ -50,4 +58,4 @@ Each commit to `master` should be releasable, otherwise make use of the `develop
     - Changelog
 
 ### Announcements
-- 
+- Where to announce new Pico release?

--- a/_plugin-dev/core.md
+++ b/_plugin-dev/core.md
@@ -1,6 +1,6 @@
 ---
 toc:
-    core:
+    pico-core:
         _title: Core
 
 nav: 2

--- a/_plugin-dev/plugins.md
+++ b/_plugin-dev/plugins.md
@@ -2,8 +2,8 @@
 toc:
     plugins:
         _title: Plugins
-        migrating: Migrating 0.X -> 1.0
-        your_first: Your First Plugin
+        migrating-from-0x---10: Migrating 0.X -> 1.0
+        your-first-plugin: Your First Plugin
 nav: 3
 ---
 
@@ -14,7 +14,7 @@ You will find a full example template in `plugins/DummyPlugin.php` to get you
 started on building some great stuff. Otherwise, keep reading to learn how to
 create your first plugin!
 
-Officially tested plugins can be found at http://pico.dev7studios.com/plugins,
+Officially tested plugins can be found at [http://picocms.org/plugins](http://picocms.org/plugins),
 but there are many awesome third-party plugins out there! A good start point
 for discovery is our [Wiki](#plugin-wiki).
 

--- a/_plugin-dev/wiki.md
+++ b/_plugin-dev/wiki.md
@@ -1,6 +1,6 @@
 ---
 toc:
-    wiki: Wiki
+    plugin-wiki: Wiki
 nav: 3
 ---
 

--- a/plugin-dev.html
+++ b/plugin-dev.html
@@ -9,7 +9,7 @@ nav: 3
     <div class="inner">
         <h1 class="aligncenter">Create your own plugins &amp; themes</h1>
         <p class="description aligncenter">
-            Pico is highly customizable - the possibilites are endless when you're in control.
+            Below is our developer documentation, you may also refer to Pico's <a href="phpDocumentor/">class documentation</a>
         </p><br />
 
         <div class="one-fourth">


### PR DESCRIPTION
*[Changed] TOC navigation and heading ID's to match, now nav works.
*[Changed] Moved class documentation/phpDocumentor link to `plugin-dev.html` page header.
*[Changed] Links from dev7studios.com/..., to picocms.org/...
*[New] Added information about `travis-ci` to the docs.
*[Removed] sentence regarding `development` branch.